### PR TITLE
Keyboard interactions: selectable lists, Escape-to-close, and duplicate-send guard

### DIFF
--- a/components/popup.js
+++ b/components/popup.js
@@ -307,6 +307,26 @@ function initPromptsPopup() {
  */
 (function setupPromptKeyboardNavigation() {
   document.addEventListener('keydown', (e) => {
+    // Handle Escape to hide open menus without closing the popup
+    if (e.key === 'Escape') {
+      const promptsPopupEl = document.getElementById('prompts-popup');
+      const tabsPopupEl = document.getElementById('tabs-popup');
+      const isPromptsOpen =
+        promptsPopupEl && !promptsPopupEl.classList.contains('invisible');
+      const isTabsOpen =
+        tabsPopupEl && !tabsPopupEl.classList.contains('invisible');
+      if (isPromptsOpen || isTabsOpen) {
+        e.preventDefault();
+        e.stopPropagation();
+        hidePopups();
+        const textarea = /** @type {HTMLTextAreaElement|null} */ (
+          document.getElementById('prompt-textarea')
+        );
+        if (textarea && !activeTabInfo.isLLM) textarea.focus();
+        return;
+      }
+    }
+
     // Tabs popup navigation
     const tabsPopup = document.getElementById('tabs-popup');
     if (tabsPopup && !tabsPopup.classList.contains('invisible')) {


### PR DESCRIPTION
- Add ArrowUp/ArrowDown navigation with highlight and auto scroll for Prompts and Tabs popups
- Enter activates selected item (prompts insert; tabs toggle), including from search input
- Escape closes Prompts/Tabs popups without closing main popup; focus returns to textarea
- Initialize/focus search on open (via “/” for prompts, “@” for tabs, or buttons)
- Reset selection index on open and filter changes
- Prevent duplicate submissions with isSending; improve send/close flow robustness

Files/notes
- components/popup.js; ~233 additions / 18 deletions
- New helpers for search focus, selection highlight, and popup init
- Safer chrome.runtime.sendMessage wrapper and teardown timing

Why
Improves keyboard-first UX, accessibility, and prevents accidental double submissions.